### PR TITLE
test role via molecule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+---
+
+name: CI
+
+on:
+  push:
+  pull_request:
+
+env:
+  galaxy-name: "cvmfs_contrib.cvmfs_client"
+
+jobs:
+
+  molecule:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        distro: [centos8]
+      fail-fast: false
+
+    steps:
+
+    - uses: actions/checkout@v2
+      with:
+        path: ${{ env.galaxy-name }}
+
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Upgrade pip
+      run: |
+        pip install --upgrade pip wheel
+        pip --version
+
+    - name: Install requirements
+      run: |
+        pip install --use-feature=2020-resolver -r requirements.txt
+      working-directory: ${{ env.galaxy-name }}
+
+    # See https://github.com/geerlingguy/raspberry-pi-dramble/issues/166
+    - name: Force GitHub Actions' docker daemon to use vfs.
+      run: |
+        sudo systemctl stop docker
+        echo '{"cgroup-parent":"/actions_job","storage-driver":"vfs"}' | sudo tee /etc/docker/daemon.json
+        sudo systemctl start docker
+
+    - name: Run molecule
+      run: molecule test
+      working-directory: ${{ env.galaxy-name }}
+      env:
+        MOLECULE_DISTRO: ${{ matrix.distro }}
+
+  # release:
+  #   name: Publish to ansible-galaxy
+  #   if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+  #   needs: [pre-commit, molecule]
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - uses: robertdebock/galaxy-action@1.0.3
+  #     with:
+  #       galaxy_api_key: ${{ secrets.GALAXY_API_KEY }}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,7 +30,7 @@ cvmfs_force_unmount: false
 # according to cvmfs_client_pv_name, cvmfs_client_vg_name, and
 # cvmfs_client_lv_name as described below. If false, you will need to
 # configure the cache storage yourself instead, and also ensure it is the required size.
-cvmfs_client_configure_storage: true
+cvmfs_client_configure_storage: false
 
 # If this block device name is defined, then a volume group, logical volume, and filesystem will be created on it.
 # If it is not defined, then a volume group is assumed to already exist and will be used instead.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,7 +30,7 @@ cvmfs_force_unmount: false
 # according to cvmfs_client_pv_name, cvmfs_client_vg_name, and
 # cvmfs_client_lv_name as described below. If false, you will need to
 # configure the cache storage yourself instead, and also ensure it is the required size.
-cvmfs_client_configure_storage: false
+cvmfs_client_configure_storage: true
 
 # If this block device name is defined, then a volume group, logical volume, and filesystem will be created on it.
 # If it is not defined, then a volume group is assumed to already exist and will be used instead.

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,0 +1,18 @@
+---
+
+- name: Converge
+  hosts: all
+  become: true
+
+  pre_tasks:
+  - name: Update apt cache.
+    apt: update_cache=yes cache_valid_time=600
+    when: ansible_os_family == 'Debian'
+
+  roles:
+  - role: cvmfs_contrib.cvmfs_client
+    vars:
+      cvmfs_cache_size: "1000"  # small cache size for CI
+      cvmfs_http_proxy: "DIRECT"
+      cvmfs_configuration:
+      - "cvmfs-config-computecanada"

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -16,4 +16,4 @@
       cvmfs_cache_size: "1000"  # small cache size for CI
       cvmfs_http_proxy: "DIRECT"
       cvmfs_client_conf:
-        CVMFS_SERVER_URL: http://cvmfs-stratum-one.cern.ch/cvmfs/atlas.cern.ch
+        CVMFS_SERVER_URL: http://cvmfs-cache.arbutus.cloud.computecanada.ca:3128

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -15,3 +15,5 @@
       cvmfs_client_configure_storage: false
       cvmfs_cache_size: "1000"  # small cache size for CI
       cvmfs_http_proxy: "DIRECT"
+      cvmfs_client_conf:
+        CVMFS_SERVER_URL: http://cvmfs-stratum-one.cern.ch/cvmfs/atlas.cern.ch

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -15,5 +15,3 @@
       cvmfs_client_configure_storage: false
       cvmfs_cache_size: "1000"  # small cache size for CI
       cvmfs_http_proxy: "DIRECT"
-      cvmfs_configuration:
-      - "cvmfs-config-computecanada"

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -12,6 +12,7 @@
   roles:
   - role: cvmfs_contrib.cvmfs_client
     vars:
+      cvmfs_client_configure_storage: false
       cvmfs_cache_size: "1000"  # small cache size for CI
       cvmfs_http_proxy: "DIRECT"
       cvmfs_configuration:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -15,5 +15,3 @@
       cvmfs_client_configure_storage: false
       cvmfs_cache_size: "1000"  # small cache size for CI
       cvmfs_http_proxy: "DIRECT"
-      cvmfs_client_conf:
-        CVMFS_SERVER_URL: http://cvmfs-cache.arbutus.cloud.computecanada.ca:3128

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,20 @@
+---
+
+dependency:
+  name: galaxy
+  options:
+    role-file: ansible-role-requirements.yml
+driver:
+  name: docker
+platforms:
+- name: instance
+  image: "geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu1804}-ansible:latest"
+  command: ${MOLECULE_DOCKER_COMMAND:-""}
+  volumes:
+  - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  privileged: true
+  pre_build_image: true
+provisioner:
+  name: ansible
+  playbooks:
+    converge: converge.yml

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Verify
+  hosts: all
+  become: true
+
+  tasks:
+  - name: Test loading the Compute Canda module environment
+    shell: source /cvmfs/soft.computecanada.ca/config/profile/bash.sh

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -5,5 +5,5 @@
   become: true
 
   tasks:
-  - name: Test loading the Compute Canda module environment
+  - name: Test loading the Compute Canada module environment
     shell: source /cvmfs/soft.computecanada.ca/config/profile/bash.sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+# for running tests
+molecule[docker]~=3.3.0
+docker~=4.4.4
+ansible~=4.8.0


### PR DESCRIPTION
Add continuous integration tests via the `molecule` package that run on
Github actions.

Test log: https://github.com/ltalirz/ansible-cvmfs-client/runs/4886355529?check_suite_focus=true