### PR TITLE
configure strict mount conditions

### DIFF
--- a/templates/default.local.j2
+++ b/templates/default.local.j2
@@ -1,5 +1,8 @@
 CVMFS_REPOSITORIES="{% for item in cvmfs_repositories %}{{ item }},{% endfor %}"
+{# refer to https://docs.computecanada.ca/wiki/Accessing_CVMFS #}
+{% if cvmfs_strict_mount|default(false) or "cvmfs-config-computecanada" in cvmfs_configuration %}
 CVMFS_STRICT_MOUNT="yes"
+{% endif %}
 {# The standard recommendation is to use 85% of the filesystem, but there is also
  # some overhead for the filesystem itself (inode tables, reserved blocks, etc.),
  # so use 82% of the size of the underlying LV. #}


### PR DESCRIPTION
Normally, do not use CVMFS_STRICT_MOUNT=yes (suitable for general purpose client) , unless CC CVMFS config is set up (related to restricted repo).

Eventually, CC repos will be available by default without requiring the CC config setup so this won't be an issue.