### PR TITLE
increase timeout to 6 min

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,7 +18,7 @@ cvmfs_configuration:
 # Switching a client system from autofs to static mode requires some manual operations and is not supported by this Ansible role.
 cvmfs_auto_setup: true
 # If static mounts are used, these mount options will be applied in /etc/fstab (see https://github.com/cvmfs/cvmfs/issues/3447).
-cvmfs_mount_opts: "defaults,_netdev,x-systemd.mount-timeout=3min"
+cvmfs_mount_opts: "defaults,_netdev,x-systemd.mount-timeout=6min"
 
 # Use FUSE3
 cvmfs_use_fuse3: true


### PR DESCRIPTION
Can take awhile on busy nodes especially if CVMFS previously crashed and a DB rebuild is needed.