### PR TITLE
enable CVMFS_CACHE_REFCOUNT by default

### DIFF
--- a/templates/default.local.j2
+++ b/templates/default.local.j2
@@ -8,6 +8,8 @@ CVMFS_STRICT_MOUNT="yes"
  # so use 82% of the size of the underlying LV. #}
 CVMFS_QUOTA_LIMIT="{{ (cvmfs_cache_size|float * 0.82)|round(0, 'floor')|int }}"
 CVMFS_HTTP_PROXY="{{ cvmfs_http_proxy }}"
+# Conserve file descriptors
+CVMFS_CACHE_REFCOUNT=yes
 # generally we do not want oomkiller to hit the CVMFS client
 CVMFS_OOM_SCORE_ADJ="-10"
 {% for key, value in cvmfs_client_conf.items() %}


### PR DESCRIPTION
The new CVMFS_CACHE_REFCOUNT setting was added in CVMFS v2.11.

Based on https://indico.cern.ch/event/1338689/contributions/6010994/attachments/2953764/5192993/presentation_prom.pdf  there is no downside to activating it, and it will be especially important for keeping file descriptor usage in check on newer many-core systems.