### PR TITLE
Revert enabling CVMFS_CACHE_REFCOUNT by default

### DIFF
--- a/templates/default.local.j2
+++ b/templates/default.local.j2
@@ -8,8 +8,6 @@ CVMFS_STRICT_MOUNT="yes"
  # so use 82% of the size of the underlying LV. #}
 CVMFS_QUOTA_LIMIT="{{ (cvmfs_cache_size|float * 0.82)|round(0, 'floor')|int }}"
 CVMFS_HTTP_PROXY="{{ cvmfs_http_proxy }}"
-# Conserve file descriptors
-CVMFS_CACHE_REFCOUNT=yes
 # generally we do not want oomkiller to hit the CVMFS client
 CVMFS_OOM_SCORE_ADJ="-10"
 {% for key, value in cvmfs_client_conf.items() %}


### PR DESCRIPTION

CVMFS 2.12 will enable the refcount cache manager by default: https://cvmfs.readthedocs.io/en/2.12/cpt-releasenotes.html
So no configuration change is needed.


This reverts commit 12b450d0476482c76943cca448780cc4a2bc503f, reversing changes made to 3ead4d93f66db981daf36f9fdf46b39fbfecc16a.