### PR TITLE
implement cvmfs_client_do_test option

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -73,6 +73,12 @@ cvmfs_repositories:
 #   https://cvmfs.readthedocs.io/en/stable/cpt-configure.html#proxy-lists
 cvmfs_http_proxy: "DIRECT"
 
+# Whether to run cvmfs_config chksetup and cvmfs_config probe
+# after installation to verify that the client is working.
+# Set to false if you are going to tweak the configuration (eg. custom key) before first use.
+
+cvmfs_client_do_test: true
+
 # This dict allows arbitrary CVMFS client settings to be applied in /etc/cvmfs/default.local .
 # Use this to apply any other settings, aside from those already defined by 
 # other variables (CVMFS_REPOSITORIES, CVMFS_QUOTA_LIMIT, CVMFS_HTTP_PROXY).

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,5 +12,4 @@
 - { import_tasks: storage.yml, tags: ['cvmfs', 'storage'], when: cvmfs_client_configure_storage | bool }
 - { import_tasks: packages.yml, tags: ['cvmfs', 'packages'] }
 - { import_tasks: config.yml, tags: ['cvmfs', 'config'] }
-- { import_tasks: test.yml, tags: ['cvmfs', 'test'] }
-
+- { import_tasks: test.yml, tags: ['cvmfs', 'test'], when: cvmfs_client_do_test | bool }


### PR DESCRIPTION
### Added
- New variable `cvmfs_client_do_test` to disable execution of `cvmfs_config chksetup` and `cvmfs_config probe`.

### Rationale
Disabling these checks allows custom configurations (e.g. adding public keys for local site repositories) to be applied after this role has run.
